### PR TITLE
add a toMatchCloseTo function

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,19 @@ Extend jest to assert arrays and objects with approximate values.
 ## Usage
 
 ```js
-import {toBeDeepCloseTo} from 'jest-matcher-deep-close-to';
-expect.extend({toBeDeepCloseTo});
+import {toBeDeepCloseTo,toMatchCloseTo} from 'jest-matcher-deep-close-to';
+expect.extend({toBeDeepCloseTo, toMatchCloseTo});
 
 describe('test myModule', () => {
     it('should return 42', () => {
         expect([42.0003]).toBeDeepCloseTo([42.0004], 3);
+    });
+});
+
+describe('test myModule', () => {
+    it('should return 42', () => {
+        expect({ foo: 42.0003,  bar: "xxx", baz: "yyy"})
+            .toMatchCloseTo({ foo: 42.004, bar: "xxx" }, 3);
     });
 });
 ```

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -97,5 +97,6 @@ describe('toMatchCloseTo', () => {
 
   it('dissimilar objects', () => {
     expect({ x: 1.4999, y: NaN, z: 100 }).toMatchCloseTo({ x: 1.5, y: NaN }, 3);
+    expect({ x: 1.4999, y: NaN, z: 100 }).toMatchCloseTo({ x: 1.5, z: 100 }, 3);
   });
 });

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -1,6 +1,6 @@
-import { toBeDeepCloseTo } from '..';
+import { toBeDeepCloseTo, toMatchCloseTo } from '..';
 
-expect.extend({ toBeDeepCloseTo });
+expect.extend({ toBeDeepCloseTo, toMatchCloseTo });
 
 describe('toBeDeepCloseTo', () => {
   it('numbers', () => {
@@ -66,5 +66,36 @@ describe('fails', () => {
 
   it('object with arrays with mismatched lengths', () => {
     expect({ x: [1.48], y: [3.01, 3.02] }).not.toBeDeepCloseTo({ x: 1.5, y: 3 }, 3);
+  });
+});
+
+describe('toMatchCloseTo', () => {
+  it('numbers', () => {
+    expect(42).toMatchCloseTo(42, 3);
+    expect(42.0003).toMatchCloseTo(42.0004, 3);
+  });
+
+  it('array', () => {
+    expect([42]).toMatchCloseTo([42], 3);
+    expect([42.0003]).toMatchCloseTo([42.0004], 3);
+  });
+
+  it('array of arrays', () => {
+    expect([[42]]).toMatchCloseTo([[42]], 3);
+    expect([[42.0003]]).toMatchCloseTo([[42.0004]], 3);
+  });
+
+  it('object with decimal values', () => {
+    expect({ x: 1.4999, y: 3.00001 }).toMatchCloseTo({ x: 1.5, y: 3 }, 3);
+    expect({ x: { a: 1.4999 }, y: 3.00001 }).toMatchCloseTo({ x: { a: 1.5 }, y: 3 }, 3);
+  });
+
+  it('object with NaN', () => {
+    expect({ x: 1.4999, y: NaN }).toMatchCloseTo({ x: 1.5, y: NaN }, 3);
+    expect({ x: 1.4999, y: 3 }).not.toMatchCloseTo({ x: 1.5, y: NaN }, 3);
+  });
+
+  it('dissimilar objects', () => {
+    expect({ x: 1.4999, y: NaN, z: 100 }).toMatchCloseTo({ x: 1.5, y: NaN }, 3);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -97,8 +97,8 @@ function recursiveCheck(actual, expected, decimals, strict = true) {
     var actualKeys = Object.keys(actual).sort();
     var expectedKeys = Object.keys(expected).sort();
     var sameLength = (!strict) || (actualKeys.length === expectedKeys.length);
-    if (!sameLength || expectedKeys.some(function (e, i) {
-      return e !== actualKeys[i];
+    if (!sameLength || expectedKeys.some(function (e) {
+      return !Object.prototype.hasOwnProperty.call(actual, e);
     })) {
       return {
         reason: 'The objects do not have similar keys',


### PR DESCRIPTION
Like toBeDeepCloseTo, but doesn't complain is the target objects are subsets of the observed ones (like jest's original toMatchObject)