### PR TITLE
break down the big comparison function into per-type pieces

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,19 @@ Extend jest to assert arrays and objects with approximate values.
 ## Usage
 
 ```js
-import {toBeDeepCloseTo} from 'jest-matcher-deep-close-to';
-expect.extend({toBeDeepCloseTo});
+import {toBeDeepCloseTo,toMatchCloseTo} from 'jest-matcher-deep-close-to';
+expect.extend({toBeDeepCloseTo, toMatchCloseTo});
 
 describe('test myModule', () => {
     it('should return 42', () => {
         expect([42.0003]).toBeDeepCloseTo([42.0004], 3);
+    });
+});
+
+describe('test myModule', () => {
+    it('should return 42', () => {
+        expect({ foo: 42.0003,  bar: "xxx", baz: "yyy"})
+            .toMatchCloseTo({ foo: 42.004, bar: "xxx" }, 3);
     });
 });
 ```

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -97,5 +97,6 @@ describe('toMatchCloseTo', () => {
 
   it('dissimilar objects', () => {
     expect({ x: 1.4999, y: NaN, z: 100 }).toMatchCloseTo({ x: 1.5, y: NaN }, 3);
+    expect({ x: 1.4999, y: NaN, z: 100 }).toMatchCloseTo({ x: 1.5, z: 100 }, 3);
   });
 });

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -1,6 +1,6 @@
-import { toBeDeepCloseTo } from '..';
+import { toBeDeepCloseTo, toMatchCloseTo } from '..';
 
-expect.extend({ toBeDeepCloseTo });
+expect.extend({ toBeDeepCloseTo, toMatchCloseTo });
 
 describe('toBeDeepCloseTo', () => {
   it('numbers', () => {
@@ -66,5 +66,36 @@ describe('fails', () => {
 
   it('object with arrays with mismatched lengths', () => {
     expect({ x: [1.48], y: [3.01, 3.02] }).not.toBeDeepCloseTo({ x: 1.5, y: 3 }, 3);
+  });
+});
+
+describe('toMatchCloseTo', () => {
+  it('numbers', () => {
+    expect(42).toMatchCloseTo(42, 3);
+    expect(42.0003).toMatchCloseTo(42.0004, 3);
+  });
+
+  it('array', () => {
+    expect([42]).toMatchCloseTo([42], 3);
+    expect([42.0003]).toMatchCloseTo([42.0004], 3);
+  });
+
+  it('array of arrays', () => {
+    expect([[42]]).toMatchCloseTo([[42]], 3);
+    expect([[42.0003]]).toMatchCloseTo([[42.0004]], 3);
+  });
+
+  it('object with decimal values', () => {
+    expect({ x: 1.4999, y: 3.00001 }).toMatchCloseTo({ x: 1.5, y: 3 }, 3);
+    expect({ x: { a: 1.4999 }, y: 3.00001 }).toMatchCloseTo({ x: { a: 1.5 }, y: 3 }, 3);
+  });
+
+  it('object with NaN', () => {
+    expect({ x: 1.4999, y: NaN }).toMatchCloseTo({ x: 1.5, y: NaN }, 3);
+    expect({ x: 1.4999, y: 3 }).not.toMatchCloseTo({ x: 1.5, y: NaN }, 3);
+  });
+
+  it('dissimilar objects', () => {
+    expect({ x: 1.4999, y: NaN, z: 100 }).toMatchCloseTo({ x: 1.5, y: NaN }, 3);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -81,20 +81,11 @@ function recursiveCheck(actual, expected, decimals, strict = true) {
     return cmpNumbers( actual, expected, decimals );
   }
 
-  if (Array.isArray(actual) && Array.isArray(expected)) {
-    if (actual.length !== expected.length) {
-      return {
-        reason: 'The arrays length does not match',
-        expected: expected.length,
-        received: actual.length
-      };
-    }
-    for (var i = 0; i < actual.length; i++) {
-      var error = recursiveCheck(actual[i], expected[i], decimals, strict);
-      if (error) return error;
-    }
-    return false;
-  } else if (expected !== null && typeof expected === 'object' && actual !== null && typeof actual === 'object') {
+  if( [actual,expected].every( Array.isArray ) ) {
+    return cmpArrays( actual, expected, decimals, strict );
+  }
+
+  if (expected !== null && typeof expected === 'object' && actual !== null && typeof actual === 'object') {
     var actualKeys = Object.keys(actual).sort();
     var expectedKeys = Object.keys(expected).sort();
     var sameLength = (!strict) || (actualKeys.length === expectedKeys.length);
@@ -112,14 +103,13 @@ function recursiveCheck(actual, expected, decimals, strict = true) {
       if (properror) return properror;
     }
     return false;
-  } else {
-    // error for all other types
-    return {
-      reason: 'The current data types are not supported',
-      expected: typeof expected,
-      received: typeof actual
-    };
   }
+  // error for all other types
+  return {
+    reason: 'The current data types are not supported or do not match',
+    expected: typeof expected,
+    received: typeof actual
+  };
 }
 
 function cmpNumbers( actual, expected,  decimals ) {
@@ -134,4 +124,21 @@ function cmpNumbers( actual, expected,  decimals ) {
     expected: expected,
     received: actual
   };
+}
+
+function cmpArrays( actual, expected, decimals, strict ) {
+    if (actual.length !== expected.length) {
+      return {
+        reason: 'The arrays length does not match',
+        expected: expected.length,
+        received: actual.length
+      };
+    }
+
+    for (var i = 0; i < actual.length; i++) {
+      var error = recursiveCheck(actual[i], expected[i], decimals, strict);
+      if (error) return error;
+    }
+
+    return false;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ function recursiveCheck(actual, expected, decimals, strict = true) {
   } else {
     // error for all other types
     return {
-      reason: 'The current data type is not supported or they do not match',
+      reason: 'The current data types are not supported',
       expected: typeof expected,
       received: typeof actual
     };

--- a/src/index.js
+++ b/src/index.js
@@ -17,16 +17,16 @@ export function toBeDeepCloseTo(received, expected, decimals) {
         `  ${this.utils.printReceived(error.received)}`,
       pass: false
     };
-  } else {
-    return {
-      message: () => `${this.utils.matcherHint('.not.toBeDeepCloseTo')}\n\n` +
-        'The two objects are deeply equal:\n' +
-        `  ${this.utils.printExpected(expected)}\n` +
-        'Received:\n' +
-        `  ${this.utils.printReceived(received)}`,
-      pass: true
-    };
   }
+
+  return {
+    message: () => `${this.utils.matcherHint('.not.toBeDeepCloseTo')}\n\n` +
+      'The two objects are deeply equal:\n' +
+      `  ${this.utils.printExpected(expected)}\n` +
+      'Received:\n' +
+      `  ${this.utils.printReceived(received)}`,
+    pass: true
+  };
 }
 
 /**
@@ -48,16 +48,16 @@ export function toMatchCloseTo(received, expected, decimals) {
         `  ${this.utils.printReceived(error.received)}`,
       pass: false
     };
-  } else {
-    return {
-      message: () => `${this.utils.matcherHint('.not.toMatchCloseTo')}\n\n` +
-        'The observed object is a subset of its target:\n' +
-        `  ${this.utils.printExpected(expected)}\n` +
-        'Received:\n' +
-        `  ${this.utils.printReceived(received)}`,
-      pass: true
-    };
   }
+
+  return {
+    message: () => `${this.utils.matcherHint('.not.toMatchCloseTo')}\n\n` +
+      'The observed object is a subset of its target:\n' +
+      `  ${this.utils.printExpected(expected)}\n` +
+      'Received:\n' +
+      `  ${this.utils.printReceived(received)}`,
+    pass: true
+  };
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -97,8 +97,8 @@ function recursiveCheck(actual, expected, decimals, strict = true) {
     var actualKeys = Object.keys(actual).sort();
     var expectedKeys = Object.keys(expected).sort();
     var sameLength = (!strict) || (actualKeys.length === expectedKeys.length);
-    if (!sameLength || expectedKeys.some(function (e, i) {
-      return e !== actualKeys[i];
+    if (!sameLength || expectedKeys.some(function (e) {
+      return !Object.prototype.hasOwnProperty.call(actual, e);
     })) {
       return {
         reason: 'The objects do not have similar keys',

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,15 @@ export function toMatchCloseTo(received, expected, decimals) {
  * @return {boolean|{reason, expected, received}}
  */
 function recursiveCheck(actual, expected, decimals, strict = true) {
+
+  if ( typeof actual !== typeof expected ) {
+    return {
+      reason: 'The data types do not match',
+      expected: typeof expected,
+      received: typeof actual
+    };
+  }
+
   if (typeof actual === 'number' && typeof expected === 'number') {
     if (isNaN(actual)) {
       return !isNaN(expected);

--- a/src/index.js
+++ b/src/index.js
@@ -85,25 +85,10 @@ function recursiveCheck(actual, expected, decimals, strict = true) {
     return cmpArrays( actual, expected, decimals, strict );
   }
 
-  if (expected !== null && typeof expected === 'object' && actual !== null && typeof actual === 'object') {
-    var actualKeys = Object.keys(actual).sort();
-    var expectedKeys = Object.keys(expected).sort();
-    var sameLength = (!strict) || (actualKeys.length === expectedKeys.length);
-    if (!sameLength || expectedKeys.some(function (e) {
-      return !Object.prototype.hasOwnProperty.call(actual, e);
-    })) {
-      return {
-        reason: 'The objects do not have similar keys',
-        expected: expectedKeys,
-        received: actualKeys,
-      };
-    }
-    for (const prop in expected) {
-      var properror = recursiveCheck(actual[prop], expected[prop], decimals, strict);
-      if (properror) return properror;
-    }
-    return false;
+  if( typeof actual === 'object' ) {
+    return cmpObjects( actual, expected, decimals, strict );
   }
+
   // error for all other types
   return {
     reason: 'The current data types are not supported or do not match',
@@ -138,6 +123,29 @@ function cmpArrays( actual, expected, decimals, strict ) {
     for (var i = 0; i < actual.length; i++) {
       var error = recursiveCheck(actual[i], expected[i], decimals, strict);
       if (error) return error;
+    }
+
+    return false;
+}
+
+function cmpObjects( actual, expected, decimals, strict ) {
+  var actualKeys = Object.keys(actual).sort();
+  var expectedKeys = Object.keys(expected).sort();
+  var sameLength = (!strict) || (actualKeys.length === expectedKeys.length);
+
+  const noActualProp = (p) => !Object.prototype.hasOwnProperty.call(actual, p);
+
+  if (!sameLength || expectedKeys.some( noActualProp ) ) {
+      return {
+        reason: 'The objects do not have similar keys',
+        expected: expectedKeys,
+        received: actualKeys,
+      };
+    }
+
+    for (const prop in expected) {
+      var properror = recursiveCheck(actual[prop], expected[prop], decimals, strict);
+      if (properror) return properror;
     }
 
     return false;

--- a/src/index.js
+++ b/src/index.js
@@ -76,20 +76,12 @@ function recursiveCheck(actual, expected, decimals, strict = true) {
       received: typeof actual
     };
   }
+  
+  if( typeof actual === 'number' ) {
+    return cmpNumbers( actual, expected, decimals );
+  }
 
-  if (typeof actual === 'number' && typeof expected === 'number') {
-    if (isNaN(actual)) {
-      return !isNaN(expected);
-    } else if ((Math.abs(actual - expected) <= Math.pow(10, -decimals))) {
-      return false;
-    } else {
-      return {
-        reason: `Expected value to be (using ${decimals} decimals)`,
-        expected: expected,
-        received: actual
-      };
-    }
-  } else if (Array.isArray(actual) && Array.isArray(expected)) {
+  if (Array.isArray(actual) && Array.isArray(expected)) {
     if (actual.length !== expected.length) {
       return {
         reason: 'The arrays length does not match',
@@ -128,4 +120,18 @@ function recursiveCheck(actual, expected, decimals, strict = true) {
       received: typeof actual
     };
   }
+}
+
+function cmpNumbers( actual, expected,  decimals ) {
+  if (isNaN(actual)) return !isNaN(expected);
+
+  if ((Math.abs(actual - expected) <= Math.pow(10, -decimals))) {
+    return false;
+  }
+
+  return {
+    reason: `Expected value to be (using ${decimals} decimals)`,
+    expected: expected,
+    received: actual
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -68,25 +68,24 @@ export function toMatchCloseTo(received, expected, decimals) {
  * @return {boolean|{reason, expected, received}}
  */
 function recursiveCheck(actual, expected, decimals, strict = true) {
-
-  if ( typeof actual !== typeof expected ) {
+  if (typeof actual !== typeof expected) {
     return {
       reason: 'The data types do not match',
       expected: typeof expected,
       received: typeof actual
     };
   }
-  
-  if( typeof actual === 'number' ) {
-    return cmpNumbers( actual, expected, decimals );
+
+  if (typeof actual === 'number') {
+    return cmpNumbers(actual, expected, decimals);
   }
 
-  if( [actual,expected].every( Array.isArray ) ) {
-    return cmpArrays( actual, expected, decimals, strict );
+  if ([actual, expected].every(Array.isArray)) {
+    return cmpArrays(actual, expected, decimals, strict);
   }
 
-  if( typeof actual === 'object' ) {
-    return cmpObjects( actual, expected, decimals, strict );
+  if (typeof actual === 'object') {
+    return cmpObjects(actual, expected, decimals, strict);
   }
 
   // error for all other types
@@ -97,7 +96,7 @@ function recursiveCheck(actual, expected, decimals, strict = true) {
   };
 }
 
-function cmpNumbers( actual, expected,  decimals ) {
+function cmpNumbers(actual, expected, decimals) {
   if (isNaN(actual)) return !isNaN(expected);
 
   if ((Math.abs(actual - expected) <= Math.pow(10, -decimals))) {
@@ -111,42 +110,42 @@ function cmpNumbers( actual, expected,  decimals ) {
   };
 }
 
-function cmpArrays( actual, expected, decimals, strict ) {
-    if (actual.length !== expected.length) {
-      return {
-        reason: 'The arrays length does not match',
-        expected: expected.length,
-        received: actual.length
-      };
-    }
+function cmpArrays(actual, expected, decimals, strict) {
+  if (actual.length !== expected.length) {
+    return {
+      reason: 'The arrays length does not match',
+      expected: expected.length,
+      received: actual.length
+    };
+  }
 
-    for (var i = 0; i < actual.length; i++) {
-      var error = recursiveCheck(actual[i], expected[i], decimals, strict);
-      if (error) return error;
-    }
+  for (var i = 0; i < actual.length; i++) {
+    var error = recursiveCheck(actual[i], expected[i], decimals, strict);
+    if (error) return error;
+  }
 
-    return false;
+  return false;
 }
 
-function cmpObjects( actual, expected, decimals, strict ) {
+function cmpObjects(actual, expected, decimals, strict) {
   var actualKeys = Object.keys(actual).sort();
   var expectedKeys = Object.keys(expected).sort();
   var sameLength = (!strict) || (actualKeys.length === expectedKeys.length);
 
   const noActualProp = (p) => !Object.prototype.hasOwnProperty.call(actual, p);
 
-  if (!sameLength || expectedKeys.some( noActualProp ) ) {
-      return {
-        reason: 'The objects do not have similar keys',
-        expected: expectedKeys,
-        received: actualKeys,
-      };
-    }
+  if (!sameLength || expectedKeys.some(noActualProp)) {
+    return {
+      reason: 'The objects do not have similar keys',
+      expected: expectedKeys,
+      received: actualKeys,
+    };
+  }
 
-    for (const prop in expected) {
-      var properror = recursiveCheck(actual[prop], expected[prop], decimals, strict);
-      if (properror) return properror;
-    }
+  for (const prop in expected) {
+    var properror = recursiveCheck(actual[prop], expected[prop], decimals, strict);
+    if (properror) return properror;
+  }
 
-    return false;
+  return false;
 }


### PR DESCRIPTION
warning: built on top of the branch `tomatchcloseto`

Basically, I just splintered the big comparision function into smaller functions that deal with each type separately.