### PR TITLE
Add support for Infinity

### DIFF
--- a/src/__tests__/deepClose.test.ts
+++ b/src/__tests__/deepClose.test.ts
@@ -53,6 +53,15 @@ describe('toBeDeepCloseTo', () => {
     expect({ x: 1.4999, y: NaN }).toBeDeepCloseTo({ x: 1.5, y: NaN }, 3);
     expect({ x: 1.4999, y: 3 }).not.toBeDeepCloseTo({ x: 1.5, y: NaN }, 3);
   });
+
+  it('object with Infinity', () => {
+    expect({ x: Infinity, y: -Infinity }).toBeDeepCloseTo(
+      { x: Infinity, y: -Infinity },
+      3,
+    );
+    expect({ x: 9999 }).not.toBeDeepCloseTo({ x: Infinity }, 3);
+    expect({ x: Infinity }).not.toBeDeepCloseTo({ x: -Infinity }, 3);
+  });
 });
 
 describe('fails', () => {

--- a/src/__tests__/matchClose.test.ts
+++ b/src/__tests__/matchClose.test.ts
@@ -108,6 +108,15 @@ describe('toMatchCloseTo', () => {
     expect({ x: 1.4999, y: 3 }).not.toMatchCloseTo({ x: 1.5, y: NaN }, 3);
   });
 
+  it('object with Infinity', () => {
+    expect({ x: Infinity, y: -Infinity }).toMatchCloseTo(
+      { x: Infinity, y: -Infinity },
+      3,
+    );
+    expect({ x: 9999 }).not.toMatchCloseTo({ x: Infinity }, 3);
+    expect({ x: Infinity }).not.toMatchCloseTo({ x: -Infinity }, 3);
+  });
+
   it('dissimilar objects', () => {
     expect({ x: 1.4999, y: NaN, z: 100 }).toMatchCloseTo({ x: 1.5, y: NaN }, 3);
     expect({ x: 1.4999, y: NaN, z: 100 }).toMatchCloseTo({ x: 1.5, z: 100 }, 3);

--- a/src/recursiveCheck.ts
+++ b/src/recursiveCheck.ts
@@ -36,6 +36,14 @@ export function recursiveCheck(
             expected,
             received,
           };
+    } else if (!isFinite(received)) {
+      return received === expected
+        ? false
+        : {
+            reason: `Expected value to be`,
+            expected,
+            received,
+          };
     } else if (Math.abs(received - expected) <= Math.pow(10, -decimals)) {
       return false;
     } else {


### PR DESCRIPTION
Currently, when a Infinite is found anywhere during comparison, the tests fails even if both sides contain the same value, showing a confusing message:
```
    Expected value to be (using 3 decimals):
      Infinity
    Received:
      Infinity
```

This PR adds support for comparing Infinite and -Infinite.