### PR TITLE
Show full diff on mismatch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+import {
+  matcherHint,
+  printExpected,
+  printReceived,
+  printDiffOrStringify,
+} from 'jest-matcher-utils';
 
 import { recursiveCheck, Iterable, Error } from './recursiveCheck';
 
@@ -20,7 +25,14 @@ function printResponse(
         `${error.reason}:\n` +
         `  ${printExpected(error.expected)}\n` +
         'Received:\n' +
-        `  ${printReceived(error.received)}`,
+        `  ${printReceived(error.received)}\n` +
+        `Full diff: \n${printDiffOrStringify(
+          expected,
+          received,
+          'Expected',
+          'Received',
+          true,
+        )}`,
       pass: false,
     };
   } else {

--- a/src/jest.d.ts
+++ b/src/jest.d.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-namespace
 declare namespace jest {
   type Iterable =
     | number

--- a/src/recursiveCheck.ts
+++ b/src/recursiveCheck.ts
@@ -80,7 +80,14 @@ export function recursiveCheck(
     }
     for (let i = 0; i < received.length; i++) {
       const error = recursiveCheck(received[i], expected[i], decimals, strict);
-      if (error) return error;
+      if (error) {
+        return {
+          ...error,
+          ...{
+            reason: `index ${i} - ${error.reason}`,
+          },
+        };
+      }
     }
     return false;
   } else if (expected === null && received === null) {
@@ -120,7 +127,14 @@ export function recursiveCheck(
         decimals,
         strict,
       );
-      if (propError) return propError;
+      if (propError) {
+        return {
+          ...propError,
+          ...{
+            reason: `key ${prop} - ${propError.reason}`,
+          },
+        };
+      }
     }
     return false;
   } else {


### PR DESCRIPTION
When a mismatch is detected on print the full diff and update message to include path through array and objects to help with debugging.