### PR TITLE
Add support for undefined type value comparison

### DIFF
--- a/src/__tests__/deepClose.test.ts
+++ b/src/__tests__/deepClose.test.ts
@@ -103,7 +103,7 @@ describe('fails', () => {
     expect([43]).not.toBeDeepCloseTo([42], 3);
     expect([42.03]).not.toBeDeepCloseTo([42.0004], 3);
     expect([null, 'hello', true, 42, undefined]).not.toBeDeepCloseTo(
-      [null, 'hello', true, 42],
+      [null, 'hello', true, 42, null],
       3,
     );
     expect([null, 'hello', true, 42.03, undefined]).not.toBeDeepCloseTo(

--- a/src/__tests__/deepClose.test.ts
+++ b/src/__tests__/deepClose.test.ts
@@ -22,6 +22,11 @@ describe('toBeDeepCloseTo', () => {
     expect(false).toBeDeepCloseTo(false, 3);
   });
 
+  it('undefined', () => {
+    expect(undefined).toBeDeepCloseTo(undefined);
+    expect(undefined).toBeDeepCloseTo(undefined, 3);
+  });
+
   it('null', () => {
     expect(null).toBeDeepCloseTo(null);
     expect(null).toBeDeepCloseTo(null, 3);
@@ -30,8 +35,8 @@ describe('toBeDeepCloseTo', () => {
   it('array', () => {
     expect([42]).toBeDeepCloseTo([42], 3);
     expect([42.0003]).toBeDeepCloseTo([42.0004], 3);
-    expect([null, 'hello', true, 42.0003]).toBeDeepCloseTo(
-      [null, 'hello', true, 42.0004],
+    expect([undefined, null, 'hello', true, 42.0003]).toBeDeepCloseTo(
+      [undefined, null, 'hello', true, 42.0004],
       3,
     );
   });
@@ -84,6 +89,11 @@ describe('fails', () => {
     expect(true).not.toBeDeepCloseTo(false, 3);
   });
 
+  it('undefined', () => {
+    expect(undefined).not.toBeDeepCloseTo(null);
+    expect(undefined).not.toBeDeepCloseTo(null, 3);
+  });
+
   it('null', () => {
     expect(null).not.toBeDeepCloseTo(undefined);
     expect(null).not.toBeDeepCloseTo(undefined, 3);
@@ -92,20 +102,24 @@ describe('fails', () => {
   it('array', () => {
     expect([43]).not.toBeDeepCloseTo([42], 3);
     expect([42.03]).not.toBeDeepCloseTo([42.0004], 3);
-    expect([null, 'hello', true, 42.03]).not.toBeDeepCloseTo(
-      [null, 'hello', true, 42.0004],
+    expect([null, 'hello', true, 42, undefined]).not.toBeDeepCloseTo(
+      [null, 'hello', true, 42],
       3,
     );
-    expect([null, 'hello', true, 42]).not.toBeDeepCloseTo(
-      [null, 'hello', false, 42],
+    expect([null, 'hello', true, 42.03, undefined]).not.toBeDeepCloseTo(
+      [null, 'hello', true, 42.0004, undefined],
       3,
     );
-    expect([null, 'hello', true, 42]).not.toBeDeepCloseTo(
-      [null, 'goodbye', true, 42],
+    expect([null, 'hello', true, 42, undefined]).not.toBeDeepCloseTo(
+      [null, 'hello', false, 42, undefined],
       3,
     );
-    expect([null, 'hello', true, 42]).not.toBeDeepCloseTo(
-      [{}, 'hello', true, 42],
+    expect([null, 'hello', true, 42, undefined]).not.toBeDeepCloseTo(
+      [null, 'goodbye', true, 42, undefined],
+      3,
+    );
+    expect([null, 'hello', true, 42, undefined]).not.toBeDeepCloseTo(
+      [{}, 'hello', true, 42, undefined],
       3,
     );
   });

--- a/src/__tests__/matchClose.test.ts
+++ b/src/__tests__/matchClose.test.ts
@@ -22,6 +22,11 @@ describe('fails', () => {
     expect(true).not.toMatchCloseTo(false, 3);
   });
 
+  it('undefined', () => {
+    expect(undefined).not.toMatchCloseTo(null);
+    expect(undefined).not.toMatchCloseTo(null, 3);
+  });
+
   it('null', () => {
     expect(null).not.toMatchCloseTo(undefined);
     expect(null).not.toMatchCloseTo(undefined, 3);
@@ -30,20 +35,24 @@ describe('fails', () => {
   it('array', () => {
     expect([43]).not.toMatchCloseTo([42], 3);
     expect([42.03]).not.toMatchCloseTo([42.0004], 3);
-    expect([null, 'hello', true, 42.03]).not.toMatchCloseTo(
-      [null, 'hello', true, 42.0004],
+    expect([null, 'hello', true, 42, undefined]).not.toMatchCloseTo(
+      [null, 'hello', true, 42, null],
       3,
     );
-    expect([null, 'hello', true, 42]).not.toMatchCloseTo(
-      [null, 'hello', false, 42],
+    expect([null, 'hello', true, 42.03, undefined]).not.toMatchCloseTo(
+      [null, 'hello', true, 42.0004, undefined],
       3,
     );
-    expect([null, 'hello', true, 42]).not.toMatchCloseTo(
-      [null, 'goodbye', true, 42],
+    expect([null, 'hello', true, 42, undefined]).not.toMatchCloseTo(
+      [null, 'hello', false, 42, undefined],
       3,
     );
-    expect([null, 'hello', true, 42]).not.toMatchCloseTo(
-      [{}, 'hello', true, 42],
+    expect([null, 'hello', true, 42, undefined]).not.toMatchCloseTo(
+      [null, 'goodbye', true, 42, undefined],
+      3,
+    );
+    expect([null, 'hello', true, 42, undefined]).not.toMatchCloseTo(
+      [{}, 'hello', true, 42, undefined],
       3,
     );
   });
@@ -120,5 +129,16 @@ describe('toMatchCloseTo', () => {
   it('dissimilar objects', () => {
     expect({ x: 1.4999, y: NaN, z: 100 }).toMatchCloseTo({ x: 1.5, y: NaN }, 3);
     expect({ x: 1.4999, y: NaN, z: 100 }).toMatchCloseTo({ x: 1.5, z: 100 }, 3);
+  });
+
+  it('explicit/implicit undefined', () => {
+    expect({ x: 1.4999, y: undefined, z: 100 }).toMatchCloseTo(
+      { y: undefined, z: 100 },
+      3,
+    );
+    expect({ x: 1.4999, y: undefined, z: 100 }).toMatchCloseTo(
+      { x: 1.5, z: 100 },
+      3,
+    );
   });
 });

--- a/src/recursiveCheck.ts
+++ b/src/recursiveCheck.ts
@@ -90,6 +90,13 @@ export function recursiveCheck(
       }
     }
     return false;
+  } else if (expected === undefined && received === undefined) {
+    /* Received and expected are either
+     * 1) both explicitly set as undefined
+     * 2) undefined properties of an object, where the received value may be implicitly undefined
+     */
+
+    return false;
   } else if (expected === null && received === null) {
     // Received and expected are null
 


### PR DESCRIPTION
Given the overall utility of using optional parameters in TypeScript interfaces, it is not unreasonable to want to test that a particular optional property within an interface object is undefined while still comparing other non-undefined properties using the `toBeDeepCloseTo` and `toMatchCloseTo` matchers. As of the current matcher found in the `master` branch, neither the`toBeDeepCloseTo` matcher nor the `toMatchCloseTo` matcher support such comparisons.

For comparison, the jest `toEqual` and `toMatchObject` matchers are able to handle undefined values in cases such as the following:
```js
expect(undefined).toEqual(undefined); // undefined is undefined
expect(undefined).not.toEqual(null); // undefined is not null
expect({ n: undefined }).toEqual({ n: undefined }); // attributes n explicitly match
expect({ n: undefined }).not.toEqual({ n: null }); // attributes n explicitly mismatch
expect({ n: undefined }).toEqual({}); // no attributes on expected object need to be checked for a match
expect({}).toEqual({ n: undefined }); // received attribute n is implicitly undefined, so it matches
expect([undefined, 3]).toEqual([undefined, 3]); // first elements are both undefined
expect([undefined, undefined]).not.toEqual([undefined]); // length mismatch takes precedence

expect({ n: undefined, a: 1 }).toMatchObject({ n: undefined, a: 1 }); // attributes n and a explicitly match
expect({ n: undefined, a: 1 }).not.toMatchObject({ n: null, a: 1 }); // attributes n explicitly mismatch
expect({ n: undefined, a: 1 }).toMatchObject({ a: 1 }); // attribute n is not in expected object and is ignored
expect({ n: undefined, a: 1 }).not.toMatchObject({ a: undefined }); // attributes a explicitly mismatch
expect({ a: 1 }).not.toMatchObject({ n: undefined, a: 1 }); // expected attribute n must be explicitly undefined
```
Many of these cases would of course just return an error with the current `toBeDeepCloseTo` and `toMatchCloseTo` matchers due to lack of undefined type values, which can come as an unpleasant surprise to some users of these matchers.

While the strictness of the existing jest matchers and the matchers added here do inherently differ, this PR aims to add undefined value support for `toBeDeepCloseTo` and `toMatchCloseTo` in a way that feels at least somewhat consistent with how `toEqual` and `toMatchObject` currently handle undefined values. 