### PR TITLE
fix: print correct diff in error message

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,7 @@ export function printCloseTo(
   const { index, key, diff } = error;
 
   if (diff !== undefined) {
-    const receivedDiff = Math.abs((received as number) - (expected as number));
+    const receivedDiff = diff;
     const expectedDiff = calculatePrecision(precision);
 
     const receivedDiffString = stringify(receivedDiff);


### PR DESCRIPTION
Previously, the `printCloseTo` function was calculating the received difference
itself using the expected and received values passed to it, even when the diff
was already part of the error object passed to it. In some cases, such as the
following, this resulted in an incorrect value being printed as the received
difference in the test output:

Test case:

```js
expect([10, 10]).toBeDeepCloseTo([10, 11], 1);
```

Before:

```
expect(received).toBeDeepCloseTo(expected)

Expected: 11
Received: 10

Index:                 1
Expected precision:    1
Expected difference: < 0.05
Received difference:   NaN
```

After:

```
expect(received).toBeDeepCloseTo(expected)

Expected: 11
Received: 10

Index:                 1
Expected precision:    1
Expected difference: < 0.05
Received difference:   1
```