### PR TITLE
Added a strict equality for functions

### DIFF
--- a/src/recursiveCheck.ts
+++ b/src/recursiveCheck.ts
@@ -40,6 +40,18 @@ function cmpEqual<T>(received: T, expected: T): CmpResult {
   };
 }
 
+function cmpFunctions(received: Function, expected: Function): CmpResult {
+  if (received !== expected) {
+    return {
+      reason: 'The functions do not match',
+      expected: expected,
+      received: received
+    }
+  }
+
+  return false
+}
+
 function cmpArray(
   received: unknown[],
   expected: unknown[],
@@ -116,6 +128,11 @@ export function recursiveCheck(
   precision: number,
   strict = true,
 ): false | Error {
+  // Received and expected are numbers
+  if (typeof received === 'function' && typeof expected === 'function') {
+    return cmpFunctions(received, expected)
+  }
+
   // Received and expected are numbers
   if (typeof received === 'number' && typeof expected === 'number') {
     return cmpNumber(received, expected, precision);


### PR DESCRIPTION
Added strict equality if function members are encountered in the nested objects being compared.
Earlier this was causing the test to fail.

More info in issue #37 