### PR TITLE
Add `decimals` default value to typings

### DIFF
--- a/src/jest.d.ts
+++ b/src/jest.d.ts
@@ -14,7 +14,7 @@ declare namespace jest {
     | boolean;
 
   interface Matchers<R> {
-    toBeDeepCloseTo: (expected: Iterable, decimals?: number) => R;
-    toMatchCloseTo: (expected: Iterable, decimals?: number) => R;
+    toBeDeepCloseTo: (expected: Iterable, decimals = 2) => R;
+    toMatchCloseTo: (expected: Iterable, decimals = 2) => R;
   }
 }


### PR DESCRIPTION
Hi! Thanks for creating this. This doesn't change the signature, but lets LSP show a more helpful tooltip.