### PR TITLE
allow the types to override the @jest/expect module

### DIFF
--- a/src/jest.d.ts
+++ b/src/jest.d.ts
@@ -18,3 +18,25 @@ declare namespace jest {
     toMatchCloseTo: (expected: Iterable, decimals?: number) => R;
   }
 }
+
+declare module '@jest/expect' {
+  interface IterableObject {
+    [k: string]: Iterable;
+  }
+  type Iterable =
+    | number
+    | Iterable[]
+    | Float32Array
+    | Float64Array
+    | IterableObject
+    | string
+    | null
+    | undefined
+    | boolean;
+
+  interface Matchers<R> {
+    toBeDeepCloseTo: (expected: Iterable, decimals?: number) => R;
+    toMatchCloseTo: (expected: Iterable, decimals?: number) => R;
+  }
+
+}


### PR DESCRIPTION
the old jest way doesn't seem to work in jest 28 but this does.

see: https://jestjs.io/blog/2022/04/25/jest-28

i had a hard to time finding a way to share these types, so i duped them for now, but lemme know if you know a way to avoid that.